### PR TITLE
fix: Prevent AI reviewer from approving PRs in GitHub Actions

### DIFF
--- a/scripts/ai-review/src/index.ts
+++ b/scripts/ai-review/src/index.ts
@@ -75,14 +75,21 @@ async function main() {
     console.log(`Found ${comments.length} issues\n`);
 
     if (comments.length === 0) {
-      console.log('✅ No issues found! Approving PR...');
+      console.log('✅ No issues found!');
 
       const commitId = await githubClient.getLatestCommit(prNumber);
+
+      // GitHub Actions cannot APPROVE PRs, use COMMENT instead
+      const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
+      const event = isGitHubActions ? 'COMMENT' : 'APPROVE';
+
+      console.log(isGitHubActions ? 'Leaving comment...' : 'Approving PR...');
+
       await githubClient.createReview(
         prNumber,
         commitId,
         [],
-        'APPROVE',
+        event,
         '✅ AI Code Review: No issues found. Code looks good!'
       );
 


### PR DESCRIPTION
## Проблема

AI ревьюер падал с ошибкой при попытке approve PR в GitHub Actions:
```
GitHub Actions is not permitted to approve pull requests.
```

Это известное ограничение GitHub - бот не может approve свои собственные PR для безопасности.

## Решение

- ✅ Определяем, что код работает в GitHub Actions через `GITHUB_ACTIONS=true` env var
- ✅ Используем `COMMENT` вместо `APPROVE` при работе в CI/CD
- ✅ В локальном режиме продолжаем использовать `APPROVE` когда проблем нет

## Тестирование

- [x] Код компилируется без ошибок
- [ ] После мержа проверим в GitHub Actions на PR #3