### PR TITLE
fix(ci): resolve E2E test timeout in CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -352,21 +352,62 @@ jobs:
       - name: Run Prisma migrations
         run: pnpm --filter api prisma:deploy
 
-      - name: Start API server
+      - name: Start API server in background
         working-directory: apps/api
         run: |
-          pnpm start &
-          sleep 5
+          node dist/server.js &
+          echo $! > api.pid
+          sleep 10
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          REDIS_URL: ${{ env.REDIS_URL }}
+          JWT_SECRET: ${{ env.JWT_SECRET }}
+          NODE_ENV: ${{ env.NODE_ENV }}
+          PORT: 4000
 
-      - name: Start Web server
+      - name: Wait for API to be ready
+        run: |
+          echo "Waiting for API to be ready..."
+          for i in {1..30}; do
+            if curl -f http://localhost:4000/api/health 2>/dev/null; then
+              echo "✅ API is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/30: API not ready yet, waiting..."
+            sleep 2
+          done
+          echo "❌ API failed to start"
+          exit 1
+
+      - name: Start Web server in background
         working-directory: apps/web
         run: |
-          pnpm preview &
-          sleep 3
+          npx vite preview --port 3000 --host &
+          echo $! > web.pid
+          sleep 5
+
+      - name: Wait for Web to be ready
+        run: |
+          echo "Waiting for Web server to be ready..."
+          for i in {1..30}; do
+            if curl -f http://localhost:3000 2>/dev/null; then
+              echo "✅ Web server is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Web not ready yet, waiting..."
+            sleep 2
+          done
+          echo "❌ Web server failed to start"
+          exit 1
 
       - name: Run E2E tests
         working-directory: apps/web
         run: pnpm test:e2e
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          REDIS_URL: ${{ env.REDIS_URL }}
+          JWT_SECRET: ${{ env.JWT_SECRET }}
+          NODE_ENV: ${{ env.NODE_ENV }}
 
       - name: Upload test results
         if: always()

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -18,10 +18,13 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
+  // В CI серверы запускаются отдельно в workflow, локально Playwright запустит сам
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'pnpm dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+        timeout: 120000,
+      },
 });

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -632,6 +632,33 @@ test('should create operation and see it in list', async ({ page }) => {
 3. Проверьте логи PostgreSQL: `docker compose logs postgres`
 4. Откатите к предыдущей версии если нужно
 
+#### Проблема: E2E тесты падают с "Timed out waiting for webServer"
+
+**Решение**:
+
+1. Проверьте `playwright.config.ts` - в CI режиме `webServer` должен быть `undefined`
+2. Убедитесь что ENV переменные передаются в workflow
+3. Проверьте что API запускается на порту 4000, Web на 3000
+4. Добавьте health checks перед запуском тестов:
+
+```yaml
+- name: Wait for API to be ready
+  run: |
+    for i in {1..30}; do
+      if curl -f http://localhost:4000/api/health; then
+        echo "✅ API is ready!"
+        exit 0
+      fi
+      sleep 2
+    done
+```
+
+5. Локальное тестирование в CI режиме:
+
+```bash
+./scripts/test-e2e-ci.sh
+```
+
 ### Local Development Issues
 
 #### Проблема: Husky hooks не работают
@@ -662,6 +689,7 @@ rm -rf packages/*/dist
 
 - [GIT_GUIDE.md](./GIT_GUIDE.md) - Работа с Git (коммиты, PR, workflow)
 - [SETUP_EXTERNAL.md](./SETUP_EXTERNAL.md) - Настройка GitHub Secrets и VPS
+- [ENV_CI_CD.md](./ENV_CI_CD.md) - ENV переменные в CI/CD
 - [DEV_GUIDE.md](./DEV_GUIDE.md) - Гид для разработчиков
 - [ARCHITECTURE.md](./ARCHITECTURE.md) - Архитектура проекта
 - [docs/ai-context/](../docs/ai-context/) - Контекст для AI review

--- a/docs/ENV_CI_CD.md
+++ b/docs/ENV_CI_CD.md
@@ -1,0 +1,173 @@
+# ENV Variables для CI/CD
+
+Документация по настройке переменных окружения для GitHub Actions CI/CD.
+
+## 🎯 Проблема
+
+В CI/CD environment нет доступа к `.env` файлу из корня проекта (он в `.gitignore`). Все переменные окружения должны быть явно объявлены в workflow.
+
+## ✅ Решение
+
+### 1. Переменные на уровне job
+
+В `.github/workflows/ci-cd.yml` переменные объявляются на уровне job:
+
+```yaml
+test-e2e:
+  name: E2E Tests
+  runs-on: ubuntu-latest
+  # ...
+  env:
+    DATABASE_URL: postgresql://postgres:postgres@localhost:5432/fin_u_ch_test
+    REDIS_URL: redis://localhost:6379
+    JWT_SECRET: test-jwt-secret
+    NODE_ENV: test
+```
+
+### 2. Переменные для шагов
+
+Некоторые шаги требуют явной передачи ENV:
+
+```yaml
+- name: Start API server in background
+  working-directory: apps/api
+  run: |
+    node dist/server.js &
+  env:
+    DATABASE_URL: ${{ env.DATABASE_URL }}
+    REDIS_URL: ${{ env.REDIS_URL }}
+    JWT_SECRET: ${{ env.JWT_SECRET }}
+    NODE_ENV: ${{ env.NODE_ENV }}
+    PORT: 4000
+```
+
+### 3. Playwright конфигурация
+
+В `apps/web/playwright.config.ts`:
+
+```typescript
+// В CI серверы запускаются отдельно в workflow, локально Playwright запустит сам
+webServer: process.env.CI
+  ? undefined
+  : {
+      command: 'pnpm dev',
+      url: 'http://localhost:3000',
+      reuseExistingServer: true,
+      timeout: 120000,
+    },
+```
+
+## 📋 Необходимые ENV переменные
+
+### Build & Test Job
+
+```yaml
+env:
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/fin_u_ch_test
+  REDIS_URL: redis://localhost:6379
+  JWT_SECRET: test-jwt-secret
+  NODE_ENV: test
+```
+
+### E2E Test Job
+
+```yaml
+env:
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/fin_u_ch_test
+  REDIS_URL: redis://localhost:6379
+  JWT_SECRET: test-jwt-secret
+  NODE_ENV: test
+  PORT: 4000 # Для API сервера
+```
+
+### Deploy Job
+
+Используются GitHub Secrets:
+
+- `VPS_HOST` - IP или hostname VPS
+- `VPS_USER` - SSH user
+- `VPS_SSH_KEY` - Private SSH key
+- `GHCR_TOKEN` - GitHub Container Registry token
+
+## 🔧 Настройка локального окружения
+
+### Для разработчика
+
+1. Скопируйте `.env.example`:
+
+```bash
+cp env.example .env
+```
+
+2. Заполните значения:
+
+```bash
+# Development
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/fin_u_ch_dev
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=your-dev-secret
+NODE_ENV=development
+PORT=4000
+```
+
+### Для Windows пользователей
+
+Убедитесь что используется правильный line ending (LF, не CRLF):
+
+```bash
+# Git config
+git config core.autocrlf input
+```
+
+Для загрузки `.env` в Node.js приложениях используется пакет `dotenv`:
+
+```typescript
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load .env from monorepo root
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
+```
+
+## 🐛 Troubleshooting
+
+### Ошибка: "Timed out waiting for webServer"
+
+**Причина**: Playwright пытается запустить webServer, который уже запущен или не может запуститься из-за отсутствия ENV.
+
+**Решение**:
+
+1. Убедитесь что в `playwright.config.ts` отключен `webServer` в CI режиме
+2. Проверьте что серверы запускаются в workflow правильно
+3. Добавьте health checks перед запуском тестов
+
+### Ошибка: "Missing required environment variable"
+
+**Причина**: ENV переменная не передана в процесс.
+
+**Решение**:
+
+1. Проверьте что переменная объявлена на уровне job в workflow
+2. Если используется в шаге, добавьте явно в `env:` секцию шага
+3. Проверьте что переменная правильно интерполируется: `${{ env.VARIABLE }}`
+
+### API/Web не запускается в CI
+
+**Причина**: Отсутствуют ENV переменные или неправильный порт.
+
+**Решение**:
+
+1. Добавьте health checks после запуска серверов
+2. Используйте явные порты: API на 4000, Web на 3000
+3. Добавьте логирование в CI для отладки
+
+## 📚 Связанные документы
+
+- [CI_CD.md](./CI_CD.md) - Полная документация CI/CD pipeline
+- [ENV_SETUP.md](./ENV_SETUP.md) - Настройка ENV для всех окружений
+- [DEV_GUIDE.md](./DEV_GUIDE.md) - Гид для разработчиков
+
+---
+
+**Последнее обновление**: 2024-10-10  
+**Автор**: DevOps Team

--- a/env.example
+++ b/env.example
@@ -154,10 +154,31 @@ PGADMIN_DEFAULT_PASSWORD=admin
 # S3_SECRET_KEY=...
 
 # ==============================================
+# CI/CD ПЕРЕМЕННЫЕ (GitHub Actions)
+# ==============================================
+# В CI/CD окружении .env файл недоступен (он в .gitignore)
+# Переменные должны быть объявлены явно в .github/workflows/ci-cd.yml
+#
+# Документация: docs/ENV_CI_CD.md
+#
+# Необходимые переменные для тестов:
+# - DATABASE_URL=postgresql://postgres:postgres@localhost:5432/fin_u_ch_test
+# - REDIS_URL=redis://localhost:6379
+# - JWT_SECRET=test-jwt-secret
+# - NODE_ENV=test
+# - PORT=4000
+#
+# GitHub Secrets (настройка через Settings → Secrets):
+# - ANTHROPIC_API_KEY - для AI Code Review
+# - GHCR_TOKEN - для Docker registry
+# - VPS_HOST, VPS_USER, VPS_SSH_KEY - для деплоя
+
+# ==============================================
 # ПРИМЕЧАНИЯ
 # ==============================================
 # 1. Не коммитьте .env файл в Git (уже в .gitignore)
 # 2. Для каждого окружения создавайте свой .env файл
-# 3. В CI/CD используйте переменные окружения или secrets
+# 3. В CI/CD используйте переменные окружения или secrets (см. выше)
 # 4. Для продакшена всегда меняйте дефолтные пароли и секреты!
+# 5. Windows пользователи: используйте LF line endings (git config core.autocrlf input)
 

--- a/scripts/test-e2e-ci.sh
+++ b/scripts/test-e2e-ci.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Script для локального тестирования E2E в CI-подобном окружении
+
+set -e
+
+echo "🧪 Testing E2E in CI-like environment"
+echo "======================================"
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if running from project root
+if [ ! -f "package.json" ]; then
+    echo -e "${RED}❌ Error: Must run from project root${NC}"
+    exit 1
+fi
+
+# Check if .env exists
+if [ ! -f ".env" ]; then
+    echo -e "${YELLOW}⚠️  Warning: .env file not found${NC}"
+    echo "Creating .env from env.example..."
+    cp env.example .env
+    echo -e "${GREEN}✅ Created .env file${NC}"
+fi
+
+# Load environment variables
+export $(grep -v '^#' .env | xargs)
+
+# Override for test environment
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/fin_u_ch_test"
+export REDIS_URL="redis://localhost:6379"
+export JWT_SECRET="test-jwt-secret"
+export NODE_ENV="test"
+export PORT=4000
+export CI=true
+
+echo ""
+echo "📦 Building packages..."
+pnpm --filter @fin-u-ch/shared build
+
+echo ""
+echo "🔨 Building API..."
+pnpm --filter api build
+
+echo ""
+echo "🔨 Building Web..."
+pnpm --filter web build
+
+echo ""
+echo "🗄️  Starting PostgreSQL and Redis..."
+docker compose -f ops/docker/docker-compose.yml up -d postgres redis
+
+echo ""
+echo "⏳ Waiting for databases to be ready..."
+sleep 5
+
+echo ""
+echo "🔄 Running Prisma migrations..."
+cd apps/api
+npx prisma migrate deploy
+cd ../..
+
+echo ""
+echo "🚀 Starting API server..."
+cd apps/api
+node dist/server.js &
+API_PID=$!
+echo "API PID: $API_PID"
+cd ../..
+
+echo ""
+echo "⏳ Waiting for API to be ready..."
+for i in {1..30}; do
+    if curl -f http://localhost:4000/api/health 2>/dev/null; then
+        echo -e "${GREEN}✅ API is ready!${NC}"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}❌ API failed to start${NC}"
+        kill $API_PID 2>/dev/null || true
+        exit 1
+    fi
+    echo "Attempt $i/30: API not ready yet, waiting..."
+    sleep 2
+done
+
+echo ""
+echo "🌐 Starting Web server..."
+cd apps/web
+npx vite preview --port 3000 --host &
+WEB_PID=$!
+echo "Web PID: $WEB_PID"
+cd ../..
+
+echo ""
+echo "⏳ Waiting for Web to be ready..."
+for i in {1..30}; do
+    if curl -f http://localhost:3000 2>/dev/null; then
+        echo -e "${GREEN}✅ Web server is ready!${NC}"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}❌ Web server failed to start${NC}"
+        kill $API_PID 2>/dev/null || true
+        kill $WEB_PID 2>/dev/null || true
+        exit 1
+    fi
+    echo "Attempt $i/30: Web not ready yet, waiting..."
+    sleep 2
+done
+
+echo ""
+echo "🎭 Running E2E tests..."
+cd apps/web
+
+# Run tests
+if pnpm test:e2e; then
+    echo -e "${GREEN}✅ E2E tests passed!${NC}"
+    TEST_RESULT=0
+else
+    echo -e "${RED}❌ E2E tests failed${NC}"
+    TEST_RESULT=1
+fi
+
+cd ../..
+
+echo ""
+echo "🧹 Cleaning up..."
+kill $API_PID 2>/dev/null || true
+kill $WEB_PID 2>/dev/null || true
+
+if [ $TEST_RESULT -eq 0 ]; then
+    echo -e "${GREEN}======================================"
+    echo -e "✅ All tests passed!${NC}"
+    echo "======================================"
+else
+    echo -e "${RED}======================================"
+    echo -e "❌ Tests failed${NC}"
+    echo "======================================"
+fi
+
+exit $TEST_RESULT
+


### PR DESCRIPTION
## 🔴 Проблема
E2E тесты падали с ошибкой `Timed out waiting 120000ms from config.webServer` при пуше в main.

## ✅ Решение
- Отключен webServer в Playwright для CI режима
- Исправлен запуск API/Web серверов в workflow с правильными портами
- Добавлены health checks перед запуском тестов
- Обновлены ENV переменные на VPS и в документации
- Создан скрипт для локального тестирования в CI-подобном окружении

## 📁 Изменения
- `.github/workflows/ci-cd.yml` - исправлен запуск серверов и health checks
- `apps/web/playwright.config.ts` - отключен webServer в CI
- `docs/ENV_CI_CD.md` - новая документация по ENV в CI/CD
- `docs/CI_CD.md` - добавлен troubleshooting для E2E
- `env.example` - добавлена секция про CI/CD
- `scripts/test-e2e-ci.sh` - скрипт для локального тестирования

## 🧪 Тестирование
После merge в dev можно слить в main и проверить что E2E тесты проходят в CI/CD.

См. подробности: `docs/ENV_CI_CD.md`