### PR TITLE
fix(ci): ensure containers restart with new images on deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -611,22 +611,19 @@ jobs:
             # Login to GHCR
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
             
-            # Remove old images to force pull new ones
-            docker rmi $(docker images "ghcr.io/${{ github.repository_owner }}/fin-u-ch-api" -q) || true
-            docker rmi $(docker images "ghcr.io/${{ github.repository_owner }}/fin-u-ch-web" -q) || true
-            docker rmi $(docker images "ghcr.io/${{ github.repository_owner }}/fin-u-ch-worker" -q) || true
-            
-            # Pull new images
-            docker compose -f docker-compose.prod.yml pull
+            # Pull new images first
+            docker compose -f docker-compose.prod.yml pull api web worker
             
             # Apply database migrations (using npx since Prisma CLI is in node_modules)
             docker compose -f docker-compose.prod.yml run --rm api npx prisma migrate deploy
             
-            # Restart services with zero downtime (use pulled images, force recreate containers)
-            docker compose -f docker-compose.prod.yml up -d --force-recreate api web worker
+            # Stop and remove old containers, then start with new images
+            docker compose -f docker-compose.prod.yml stop api web worker
+            docker compose -f docker-compose.prod.yml rm -f api web worker
+            docker compose -f docker-compose.prod.yml up -d api web worker
             
-            # Cleanup old images
-            docker image prune -f
+            # Cleanup old unused images
+            docker image prune -af || docker image prune -f
             
             echo "Deployment completed successfully!"
           EOF


### PR DESCRIPTION
## 🔴 Проблема

При деплое на production контейнеры не перезапускались с новыми образами.

**Root cause**: 
- Команда `docker rmi` пыталась удалить образы, которые использовались запущенными контейнерами → FAIL
- `docker compose up -d --force-recreate` не пересоздавала контейнеры
- В результате контейнеры продолжали работать со старыми образами

**Логи**:
```
Error: unable to delete 639461bc9517 (cannot be forced) - image is being used by running container
```

## ✅ Решение

Изменен порядок команд в deploy job:

1. **Pull новых образов** ← сначала
2. **Применить миграции**
3. **Stop старых контейнеров** ← новое
4. **Remove старых контейнеров** ← новое
5. **Up новых контейнеров** ← автоматически использует latest образы
6. **Cleanup неиспользуемых образов**

## 🧪 Тестирование

- Проверено вручную на VPS - dark mode появился после ручного перезапуска
- После merge в dev и main - контейнеры будут автоматически обновляться

## 📝 Изменения

- `.github/workflows/ci-cd.yml` - исправлен порядок команд в deploy job