### PR TITLE
fix(ci): ensure docker-build and deploy run on push to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -492,7 +492,11 @@ jobs:
   docker-build:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' && 
+      github.event_name == 'push' &&
+      needs.build-and-test.result == 'success'
     needs: [build-and-test]
     timeout-minutes: 25
 
@@ -558,7 +562,11 @@ jobs:
   deploy:
     name: Deploy to VPS
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' && 
+      github.event_name == 'push' &&
+      needs.docker-build.result == 'success'
     needs: [docker-build]
     timeout-minutes: 10
     environment:


### PR DESCRIPTION
## 🐛 Проблема

После merge PR #33 docker-build и deploy не запускались при push в main.

**Причины:**
1. Отсутствовала проверка `github.event_name == 'push'`
2. При разрешении конфликта была потеряна часть оптимизации
3. Неявная зависимость от skipped джобов нарушала цепочку

## ✅ Решение

Добавлены явные условия с `always()`:

```yaml
docker-build:
  if: |
    always() &&
    github.ref == 'refs/heads/main' && 
    github.event_name == 'push' &&
    needs.build-and-test.result == 'success'
```

**Что это дает:**
- ✅ Docker и deploy запустятся при push в main
- ✅ Работает даже если quick-checks был skipped
- ✅ Проверяет success предыдущего джоба
- ❌ Не запустится для PR (только push)

## 🧪 Тестирование

После merge этого PR в dev → main должны запуститься:
1. ✅ build-and-test
2. ✅ docker-build 
3. ✅ deploy

## 📋 Чеклист

- [x] Исправлены условия docker-build
- [x] Исправлены условия deploy
- [x] Добавлены проверки event_name
- [x] Добавлен always() для цепочки зависимостей