### PR TITLE
fix(deploy): include nginx in container update process

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -636,7 +636,7 @@ jobs:
 
           # Pull new images
           echo "=== Pulling new images ==="
-          docker compose -f docker-compose.prod.yml pull api web worker
+          docker compose -f docker-compose.prod.yml pull api web worker nginx
 
           # Check available images
           echo "=== Available images ==="
@@ -648,12 +648,12 @@ jobs:
 
           # Stop and remove old containers
           echo "=== Stopping and removing old containers ==="
-          docker compose -f docker-compose.prod.yml stop api web worker
-          docker compose -f docker-compose.prod.yml rm -f api web worker
+          docker compose -f docker-compose.prod.yml stop api web worker nginx
+          docker compose -f docker-compose.prod.yml rm -f api web worker nginx
 
           # Start with new images
           echo "=== Starting containers with new images ==="
-          docker compose -f docker-compose.prod.yml up -d --force-recreate --pull always api web worker
+          docker compose -f docker-compose.prod.yml up -d --force-recreate --pull always api web worker nginx
 
           # Wait for health checks
           echo "=== Waiting for services to be healthy (30 seconds) ==="


### PR DESCRIPTION
## Проблема
Деплой завершался с 502 ошибкой из-за того, что nginx контейнер не обновлялся и оставался в состоянии `unhealthy`.

## Причина
В workflow CI/CD nginx контейнер не был включен в процесс обновления:
- Не включался в `docker compose pull`
- Не включался в `docker compose stop/rm`  
- Не включался в `docker compose up`

## Решение
✅ Добавлен nginx во все команды обновления контейнеров:
- `docker compose pull api web worker nginx`
- `docker compose stop api web worker nginx`
- `docker compose rm -f api web worker nginx`
- `docker compose up -d --force-recreate --pull always api web worker nginx`

## Результат
Теперь nginx контейнер будет обновляться вместе с остальными сервисами, что должно устранить 502 ошибку.

**Статус:** Готово к тестированию 🚀