### PR TITLE
fix(web): restore dark theme support for OffCanvas and catalog forms

### DIFF
--- a/apps/web/src/pages/catalogs/AccountsPage.tsx
+++ b/apps/web/src/pages/catalogs/AccountsPage.tsx
@@ -69,7 +69,9 @@ export const AccountsPage = () => {
     <Layout>
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900">Счета</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Счета
+          </h1>
           <Button
             onClick={() => {
               setEditing(null);
@@ -169,11 +171,12 @@ export const AccountForm = ({
         value={openingBalance}
         onChange={(e) => setOpeningBalance(e.target.value)}
       />
-      <label className="flex items-center gap-2">
+      <label className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
         <input
           type="checkbox"
           checked={isActive}
           onChange={(e) => setIsActive(e.target.checked)}
+          className="w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
         />
         <span className="text-sm">Активен</span>
       </label>

--- a/apps/web/src/pages/catalogs/ArticlesPage.tsx
+++ b/apps/web/src/pages/catalogs/ArticlesPage.tsx
@@ -80,7 +80,9 @@ export const ArticlesPage = () => {
     <Layout>
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900">Статьи</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Статьи
+          </h1>
           <Button onClick={handleCreate}>Создать статью</Button>
         </div>
 
@@ -165,11 +167,12 @@ export const ArticleForm = ({
         ]}
         required
       />
-      <label className="flex items-center gap-2">
+      <label className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
         <input
           type="checkbox"
           checked={isActive}
           onChange={(e) => setIsActive(e.target.checked)}
+          className="w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
         />
         <span className="text-sm">Активна</span>
       </label>

--- a/apps/web/src/pages/catalogs/CounterpartiesPage.tsx
+++ b/apps/web/src/pages/catalogs/CounterpartiesPage.tsx
@@ -71,7 +71,9 @@ export const CounterpartiesPage = () => {
     <Layout>
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900">Контрагенты</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Контрагенты
+          </h1>
           <Button
             onClick={() => {
               setEditing(null);

--- a/apps/web/src/pages/catalogs/DealsPage.tsx
+++ b/apps/web/src/pages/catalogs/DealsPage.tsx
@@ -65,7 +65,9 @@ export const DealsPage = () => {
     <Layout>
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900">Сделки</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Сделки
+          </h1>
           <Button
             onClick={() => {
               setEditing(null);

--- a/apps/web/src/pages/catalogs/DepartmentsPage.tsx
+++ b/apps/web/src/pages/catalogs/DepartmentsPage.tsx
@@ -55,7 +55,9 @@ export const DepartmentsPage = () => {
     <Layout>
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900">Подразделения</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Подразделения
+          </h1>
           <Button
             onClick={() => {
               setEditing(null);

--- a/apps/web/src/pages/catalogs/SalariesPage.tsx
+++ b/apps/web/src/pages/catalogs/SalariesPage.tsx
@@ -80,7 +80,9 @@ export const SalariesPage = () => {
     <Layout>
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900">Зарплаты</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Зарплаты
+          </h1>
           <Button
             onClick={() => {
               setEditing(null);
@@ -103,7 +105,6 @@ export const SalariesPage = () => {
         isOpen={isFormOpen}
         onClose={() => setIsFormOpen(false)}
         title={editing ? 'Редактировать' : 'Создать'}
-        size="lg"
       >
         <SalaryForm salary={editing} onClose={() => setIsFormOpen(false)} />
       </OffCanvas>

--- a/apps/web/src/shared/ui/OffCanvas.tsx
+++ b/apps/web/src/shared/ui/OffCanvas.tsx
@@ -42,8 +42,8 @@ export const OffCanvas = ({
       )}
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      {/* Оверлей */}
-      <div className="absolute inset-0 bg-black bg-opacity-50" />
+      {/* Оверлей — затемнение фона */}
+      <div className="absolute inset-0 bg-black bg-opacity-50 dark:bg-opacity-70" />
 
       {/* OffCanvas (Drawer) */}
       <div
@@ -52,8 +52,10 @@ export const OffCanvas = ({
           'absolute top-0 right-0 h-full w-full',
           // Десктоп: фиксированная ширина 400px
           'md:w-[400px] md:max-w-none',
+          // Фон и тень — с поддержкой темы
+          'bg-white shadow-xl dark:bg-gray-800 dark:shadow-gray-900/50',
           // Общие стили
-          'bg-white shadow-xl transform transition-transform duration-300 ease-in-out z-50 flex flex-col'
+          'transform transition-transform duration-300 ease-in-out z-50 flex flex-col'
         )}
         role="dialog"
         aria-modal="true"
@@ -61,18 +63,18 @@ export const OffCanvas = ({
       >
         {/* Header */}
         {title && (
-          <div className="flex items-center justify-between px-6 py-4 border-b">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
             <h2
               data-testid="offcanvas-title"
               id="offcanvas-title"
-              className="text-xl font-semibold text-gray-900"
+              className="text-xl font-semibold text-gray-900 dark:text-gray-100"
             >
               {title}
             </h2>
             <button
               type="button"
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
               aria-label="Закрыть"
             >
               <svg
@@ -93,7 +95,9 @@ export const OffCanvas = ({
         )}
 
         {/* Content */}
-        <div className="px-6 py-4 overflow-y-auto flex-1">{children}</div>
+        <div className="px-6 py-4 overflow-y-auto flex-1 text-gray-900 dark:text-gray-100">
+          {children}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 🐛 Problem
Dark theme styles were lost in OffCanvas and catalog forms after PR #55 merge.

## ✨ Solution
- Restore dark theme styles in OffCanvas component (overlay, background, borders, text)
- Add dark theme support for checkboxes in ArticlesPage and AccountsPage forms
- Add dark theme support for page titles in all catalog pages
- Remove invalid size prop from OffCanvas in SalariesPage
- Ensure consistent dark theme experience across all catalog forms

## 📋 Files Changed
- `apps/web/src/pages/catalogs/AccountsPage.tsx`
- `apps/web/src/pages/catalogs/ArticlesPage.tsx`
- `apps/web/src/pages/catalogs/CounterpartiesPage.tsx`
- `apps/web/src/pages/catalogs/DealsPage.tsx`
- `apps/web/src/pages/catalogs/DepartmentsPage.tsx`
- `apps/web/src/pages/catalogs/SalariesPage.tsx`
- `apps/web/src/shared/ui/OffCanvas.tsx`

## ✅ Checklist
- [x] Dark theme works correctly in all catalog forms
- [x] No invalid props passed to components
- [x] Consistent styling across all pages