### PR TITLE
feat: add auto-refresh tokens for RTK Query

### DIFF
--- a/apps/web/src/shared/api/axios.ts
+++ b/apps/web/src/shared/api/axios.ts
@@ -22,45 +22,11 @@ apiClient.interceptors.request.use(
   }
 );
 
-// Response interceptor - обработка 401 и refresh token
-apiClient.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-
-    // Если 401 и это не повторный запрос
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-
-      try {
-        const refreshToken = localStorage.getItem('refreshToken');
-        if (!refreshToken) {
-          throw new Error('No refresh token');
-        }
-
-        // Попытка обновить токен
-        const response = await axios.post(`${config.apiUrl}/auth/refresh`, {
-          refreshToken,
-        });
-
-        const { accessToken, refreshToken: newRefreshToken } = response.data;
-
-        // Сохраняем новые токены
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', newRefreshToken);
-
-        // Повторяем оригинальный запрос
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-        return apiClient(originalRequest);
-      } catch (refreshError) {
-        // Если refresh не удался - разлогиниваем
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        window.location.href = '/login';
-        return Promise.reject(refreshError);
-      }
-    }
-
-    return Promise.reject(error);
-  }
-);
+// Response interceptor - теперь не нужен, так как RTK Query сам обрабатывает 401
+// apiClient.interceptors.response.use(
+//   (response) => response,
+//   async (error) => {
+//     // Логика рефреша токенов перенесена в baseQueryWithReauth в RTK Query
+//     return Promise.reject(error);
+//   }
+// );

--- a/apps/web/src/store/api/apiSlice.ts
+++ b/apps/web/src/store/api/apiSlice.ts
@@ -1,6 +1,13 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import {
+  createApi,
+  fetchBaseQuery,
+  BaseQueryFn,
+  FetchArgs,
+  FetchBaseQueryError,
+} from '@reduxjs/toolkit/query/react';
 import { config } from '../../shared/config/env';
 import type { RootState } from '../store';
+import { setCredentials, logout } from '../slices/authSlice';
 
 const baseQuery = fetchBaseQuery({
   baseUrl: config.apiUrl,
@@ -15,9 +22,66 @@ const baseQuery = fetchBaseQuery({
   },
 });
 
+const baseQueryWithReauth: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  let result = await baseQuery(args, api, extraOptions);
+
+  // Если получили 401, пытаемся рефрешить токен
+  // Тест: можно временно изменить JWT_ACCESS_EXPIRES_IN на 1m и проверить авто-рефреш
+  if (result.error && result.error.status === 401) {
+    const refreshToken = localStorage.getItem('refreshToken');
+
+    if (refreshToken) {
+      try {
+        // Делаем запрос на рефреш напрямую (минуя RTK Query, чтобы избежать рекурсии)
+        const refreshResponse = await fetch(`${config.apiUrl}/auth/refresh`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ refreshToken }),
+        });
+
+        if (refreshResponse.ok) {
+          const refreshData = await refreshResponse.json();
+
+          // Обновляем токены в store и localStorage
+          api.dispatch(
+            setCredentials({
+              user: refreshData.user,
+              accessToken: refreshData.accessToken,
+              refreshToken: refreshData.refreshToken,
+            })
+          );
+
+          // Повторяем оригинальный запрос с новым токеном
+          result = await baseQuery(args, api, extraOptions);
+        } else {
+          // Рефреш не удался - разлогиниваем
+          api.dispatch(logout());
+          window.location.href = '/login';
+        }
+      } catch (error) {
+        // Ошибка при рефреше - разлогиниваем
+        api.dispatch(logout());
+        window.location.href = '/login';
+      }
+    } else {
+      // Нет refresh токена - разлогиниваем
+      api.dispatch(logout());
+      window.location.href = '/login';
+    }
+  }
+
+  return result;
+};
+
 export const apiSlice = createApi({
   reducerPath: 'api',
-  baseQuery,
+  baseQuery: baseQueryWithReauth,
   tagTypes: [
     'User',
     'Article',

--- a/apps/web/src/store/api/authApi.ts
+++ b/apps/web/src/store/api/authApi.ts
@@ -21,6 +21,10 @@ interface AuthResponse {
   refreshToken: string;
 }
 
+interface RefreshRequest {
+  refreshToken: string;
+}
+
 export const authApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     login: builder.mutation<AuthResponse, LoginRequest>({
@@ -41,7 +45,19 @@ export const authApi = apiSlice.injectEndpoints({
       query: () => '/users/me',
       providesTags: ['User'],
     }),
+    refresh: builder.mutation<AuthResponse, RefreshRequest>({
+      query: (data) => ({
+        url: '/auth/refresh',
+        method: 'POST',
+        body: data,
+      }),
+    }),
   }),
 });
 
-export const { useLoginMutation, useRegisterMutation, useGetMeQuery } = authApi;
+export const {
+  useLoginMutation,
+  useRegisterMutation,
+  useGetMeQuery,
+  useRefreshMutation,
+} = authApi;


### PR DESCRIPTION
## Проблема
Пользователи получали 401 ошибки через ~15 минут после логина из-за истечения access-токена. RTK Query не имел механизма авто-рефреша токенов.

## Решение
- Добавлен refresh endpoint в authApi
- Реализован baseQueryWithReauth для автоматического рефреша токенов при 401
- Заменен baseQuery на baseQueryWithReauth в apiSlice
- Отключен старый axios-интерсептор (больше не нужен)

## Изменения
- `apps/web/src/store/api/authApi.ts`: Добавлен refresh mutation
- `apps/web/src/store/api/apiSlice.ts`: Добавлена логика baseQueryWithReauth
- `apps/web/src/shared/api/axios.ts`: Закомментирован старый интерсептор

## Результат
- ✅ Нет больше 401 ошибок через 15 минут
- ✅ Пользователь остается залогиненным пока refresh-токен валиден (7 дней)
- ✅ Единая система авторизации через RTK Query
- ✅ Автоматический logout при истечении refresh-токена

## Тестирование
Для быстрого теста можно временно изменить `JWT_ACCESS_EXPIRES_IN=1m` и проверить авто-рефреш.