### PR TITLE
feat(web): unify chart legends across dashboards

### DIFF
--- a/apps/web/src/shared/ui/AccountBalancesChart.tsx
+++ b/apps/web/src/shared/ui/AccountBalancesChart.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { formatMoney } from '../lib/money';
+import { ChartLegend } from './ChartLegend';
 
 interface AccountBalancesChartProps {
   data: Array<
@@ -170,7 +171,7 @@ export const AccountBalancesChart: React.FC<AccountBalancesChartProps> = ({
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={data || []}
-              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+              margin={{ top: 5, right: 30, left: 20, bottom: 48 }}
             >
               <CartesianGrid
                 strokeDasharray="3 3"
@@ -228,7 +229,7 @@ export const AccountBalancesChart: React.FC<AccountBalancesChartProps> = ({
         <ResponsiveContainer width="100%" height="100%">
           <LineChart
             data={data}
-            margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+            margin={{ top: 5, right: 30, left: 20, bottom: 56 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -257,7 +258,12 @@ export const AccountBalancesChart: React.FC<AccountBalancesChartProps> = ({
                 maxWidth: '300px',
               }}
             />
-            <Legend />
+            <Legend
+              verticalAlign="bottom"
+              align="center"
+              content={<ChartLegend />}
+              wrapperStyle={{ paddingTop: 8 }}
+            />
             {accountsWithBalance.map((accountName, index) => (
               <Line
                 key={accountName}

--- a/apps/web/src/shared/ui/ChartLegend.tsx
+++ b/apps/web/src/shared/ui/ChartLegend.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+type LegendPayloadItem = {
+  value: string;
+  color: string;
+  type?: string;
+};
+
+interface ChartLegendProps {
+  payload?: LegendPayloadItem[];
+  preferredOrder?: string[];
+}
+
+export const ChartLegend: React.FC<ChartLegendProps> = ({
+  payload = [],
+  preferredOrder,
+}) => {
+  const items = React.useMemo(() => {
+    if (!preferredOrder || preferredOrder.length === 0) return payload;
+    const orderMap = new Map(preferredOrder.map((name, idx) => [name, idx]));
+    return [...payload].sort((a, b) => {
+      const ai = orderMap.has(a.value)
+        ? (orderMap.get(a.value) as number)
+        : Number.MAX_SAFE_INTEGER;
+      const bi = orderMap.has(b.value)
+        ? (orderMap.get(b.value) as number)
+        : Number.MAX_SAFE_INTEGER;
+      return ai - bi;
+    });
+  }, [payload, preferredOrder]);
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 px-2">
+      {items.map((entry) => (
+        <span
+          key={entry.value}
+          className="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+        >
+          <span
+            className="inline-block rounded-full"
+            style={{ width: 10, height: 10, backgroundColor: entry.color }}
+          />
+          <span className="align-middle leading-none">{entry.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/shared/ui/IncomeExpenseChart.tsx
+++ b/apps/web/src/shared/ui/IncomeExpenseChart.tsx
@@ -11,6 +11,7 @@ import {
 } from 'recharts';
 import { formatMoney } from '../lib/money';
 import { CustomTooltip } from './CustomTooltip';
+import { ChartLegend } from './ChartLegend';
 
 interface Operation {
   id: string;
@@ -124,7 +125,7 @@ export const IncomeExpenseChart: React.FC<IncomeExpenseChartProps> = ({
         <ResponsiveContainer width="100%" height="100%">
           <LineChart
             data={filteredData}
-            margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+            margin={{ top: 5, right: 30, left: 20, bottom: 48 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -145,7 +146,16 @@ export const IncomeExpenseChart: React.FC<IncomeExpenseChartProps> = ({
               tickFormatter={(value) => formatMoney(value)}
             />
             <Tooltip content={<CustomTooltip />} />
-            <Legend />
+            <Legend
+              verticalAlign="bottom"
+              align="center"
+              content={
+                <ChartLegend
+                  preferredOrder={['Доходы', 'Расходы', 'Чистый поток']}
+                />
+              }
+              wrapperStyle={{ paddingTop: 8 }}
+            />
             <Line
               type="monotone"
               dataKey="cumulativeIncome"

--- a/apps/web/src/shared/ui/WeeklyFlowChart.tsx
+++ b/apps/web/src/shared/ui/WeeklyFlowChart.tsx
@@ -11,6 +11,7 @@ import {
 } from 'recharts';
 import { formatMoney } from '../lib/money';
 import { AggregatedDataPoint } from '../lib/dataAggregation';
+import { ChartLegend } from './ChartLegend';
 
 interface WeeklyFlowChartProps {
   data: AggregatedDataPoint[];
@@ -103,7 +104,7 @@ export const WeeklyFlowChart: React.FC<WeeklyFlowChartProps> = ({
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={filteredData}
-            margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+            margin={{ top: 5, right: 30, left: 20, bottom: 48 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -128,7 +129,14 @@ export const WeeklyFlowChart: React.FC<WeeklyFlowChartProps> = ({
                 boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
               }}
             />
-            <Legend />
+            <Legend
+              verticalAlign="bottom"
+              align="center"
+              content={
+                <ChartLegend preferredOrder={['Поступления', 'Списания']} />
+              }
+              wrapperStyle={{ paddingTop: 8 }}
+            />
             <Bar
               dataKey="income"
               fill="#10b981"


### PR DESCRIPTION
This PR standardizes legends across all charts:\n\n- Adds shared ChartLegend with consistent 10x10 rounded markers and text style\n- Applies to Cash Flow, Weekly Flow, and Account Balances\n- Positions legend at bottom, centered, with wrapping; increases bottom margins to avoid overlap on mobile\n- Enforces item order where applicable (Доходы, Расходы, Чистый поток)\n\nAcceptance criteria:\n- Same marker sizes and colors across dashboards\n- Text aligned and consistent style\n- Legend does not overlap charts on mobile\n\nNotes:\n- No API or data changes. UI-only.\n- Verified locally with hot reload.