### PR TITLE
fix(worker): resolve ES module __dirname error

### DIFF
--- a/apps/worker/src/config/env.ts
+++ b/apps/worker/src/config/env.ts
@@ -1,6 +1,11 @@
 import dotenv from 'dotenv';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Try to find .env file in current dir, parent, or grandparent (monorepo root)
 function findEnvFile(): string {


### PR DESCRIPTION
## 🔧 Hotfix: Worker ES Module Error

### Проблема:
Worker контейнер не запускался из-за ошибки 

### Решение:
Заменил  на ES-совместимую версию с использованием 

### Изменения:
- ✅ Добавлен импорт  и 
- ✅ Создана ES-совместимая версия 
- ✅ Worker теперь корректно запускается в production

### Критичность: HIGH
Это hotfix для production, требует немедленного деплоя.