### PR TITLE
fix: исправлена навигация в сайдбаре для страницы бюджета

### DIFF
--- a/apps/web/src/shared/ui/Layout.tsx
+++ b/apps/web/src/shared/ui/Layout.tsx
@@ -247,7 +247,18 @@ export const Layout = ({ children }: LayoutProps): JSX.Element => {
     editingData?: unknown; // Данные для редактирования
   }>({ isOpen: false, title: '', catalogType: '' });
 
-  const isActive = (href: string): boolean => location.pathname === href;
+  const isActive = (href: string): boolean => {
+    // Точное совпадение
+    if (location.pathname === href) {
+      return true;
+    }
+    // Для вложенных маршрутов проверяем, начинается ли путь с href + "/"
+    // Например, /budgets/123 должен быть активным для href="/budgets"
+    if (href !== '/' && location.pathname.startsWith(href + '/')) {
+      return true;
+    }
+    return false;
+  };
 
   const isPopoverActive = (itemName: string): boolean =>
     menuPopoverState.isOpen && menuPopoverState.activeParentName === itemName;


### PR DESCRIPTION
## Описание

Исправлена проблема, когда при нахождении на странице детального просмотра бюджета (/budgets/:budgetId) пункт меню 'Бюджеты' в сайдбаре не подсвечивался как активный.

## Изменения

- Обновлена функция `isActive` в `Layout.tsx` для поддержки вложенных маршрутов
- Теперь функция проверяет не только точное совпадение пути, но и случаи, когда текущий путь начинается с href + '/'

## Тестирование

- [x] Проверено, что пункт 'Бюджеты' подсвечивается на странице /budgets
- [x] Проверено, что пункт 'Бюджеты' подсвечивается на странице /budgets/:budgetId
- [x] Проверено, что другие пункты меню работают корректно