### PR TITLE
fix: добавить проверку лимита пользователей для роута /invite

### DIFF
--- a/apps/api/src/modules/users/users.routes.ts
+++ b/apps/api/src/modules/users/users.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../../middlewares/auth';
 import { extractTenant } from '../../middlewares/tenant';
 import { requirePermission } from '../../middlewares/permissions';
+import { checkUserLimit } from '../../middlewares/user-limit.guard';
 import usersController from './users.controller';
 
 const router: Router = Router();
@@ -254,6 +255,7 @@ router.get('/', requirePermission('users', 'read'), usersController.getAll);
 router.post(
   '/invite',
   requirePermission('users', 'create'),
+  checkUserLimit,
   usersController.inviteUser
 );
 


### PR DESCRIPTION
## Описание

Исправлена проблема, когда пользователи с тарифом TEAM не могли добавлять новых пользователей из-за отсутствия проверки лимита пользователей.

## Изменения

- Добавлен middleware `checkUserLimit` в роут `POST /api/users/invite`
- Теперь перед приглашением пользователя выполняется проверка лимита пользователей для текущего тарифного плана

## Проблема

На тарифе TEAM (maxUsers: 5) пользователи не могли добавлять новых пользователей, так как проверка лимита не выполнялась на уровне API.

## Решение

Добавлен middleware `checkUserLimit` из `user-limit.guard.ts` в роут приглашения пользователей. Теперь:

- Для тарифа **TEAM** (maxUsers: 5) - добавление блокируется, если уже достигнут лимит
- Для тарифа **BUSINESS** (maxUsers: Infinity) - ограничений нет
- Для тарифа **START** (maxUsers: 1) - можно добавить только одного пользователя

## Тестирование

- [x] Линтер прошел успешно
- [x] Проверка типов прошла успешно
- [x] Код соответствует стандартам проекта