### PR TITLE
fix: исправить тип chat_id в alertmanager (integer вместо string)

### DIFF
--- a/ops/monitoring/alertmanager/alertmanager.yml
+++ b/ops/monitoring/alertmanager/alertmanager.yml
@@ -27,7 +27,7 @@ receivers:
   - name: 'telegram'
     telegram_configs:
       - bot_token: '${TELEGRAM_BOT_TOKEN}'
-        chat_id: '${TELEGRAM_CHAT_ID}'
+        chat_id: ${TELEGRAM_CHAT_ID}
         parse_mode: 'HTML'
         message: |
           <b>Alert:</b> {{ .GroupLabels.alertname }}
@@ -38,7 +38,7 @@ receivers:
   - name: 'telegram-critical'
     telegram_configs:
       - bot_token: '${TELEGRAM_BOT_TOKEN}'
-        chat_id: '${TELEGRAM_CHAT_ID}'
+        chat_id: ${TELEGRAM_CHAT_ID}
         parse_mode: 'HTML'
         message: |
           🚨 <b>CRITICAL ALERT</b> 🚨
@@ -50,7 +50,7 @@ receivers:
   - name: 'telegram-warning'
     telegram_configs:
       - bot_token: '${TELEGRAM_BOT_TOKEN}'
-        chat_id: '${TELEGRAM_CHAT_ID}'
+        chat_id: ${TELEGRAM_CHAT_ID}
         parse_mode: 'HTML'
         message: |
           ⚠️ <b>WARNING</b> ⚠️


### PR DESCRIPTION
## Проблема

После фикса `envsubst → sed` из PR #207 alertmanager всё равно падал с ошибкой:
```
yaml: unmarshal errors:
  line 30: cannot unmarshal !!str `-496438...` into int64
```

Telegram `chat_id` в Alertmanager должен быть `int64`. В шаблоне значение было обёрнуто в кавычки: `chat_id: '${TELEGRAM_CHAT_ID}'`, что давало строку после подстановки.

## Фикс

Убраны кавычки вокруг `${TELEGRAM_CHAT_ID}` во всех трёх receivers.

## Статус на сервере

Alertmanager поднят и работает (проверено live):
```
Completed loading of configuration file
Listening on [::]:9093
gossip settled; proceeding
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)